### PR TITLE
Remove tautological reference to 'legally binding'

### DIFF
--- a/us-interpretation.md
+++ b/us-interpretation.md
@@ -36,4 +36,4 @@ Unless the terms and conditions of the Agreement explicitly state otherwise, the
 Defined terms in this document will have the meanings described below.
 
 ### Agreement
-means the terms and conditions constituting the legally binding agreement that incorporates this document.
+means the terms and conditions constituting the agreement that incorporates this document.


### PR DESCRIPTION
As a matter of principle, I think it makes sense to keep things as concise as possible in these language repos.  Thoughts?  If we make this change, it makes sense to update the other repos.